### PR TITLE
Handle delete key for textbox

### DIFF
--- a/main.js
+++ b/main.js
@@ -4398,6 +4398,14 @@ function Text(text, pos) {
             } else {
                 text = this.replace_selected_text("");
             }
+        } else if (key === "Delete") {
+            if (!this.is_text_selected()) {
+                this.cursor_selection = this.cursor + 1;
+                this.constrain_cursors();
+                text = this.replace_selected_text("");
+            } else {
+                text = this.replace_selected_text("");
+            }
         } else if (key.length == 1) {
             // type character
             if (this.is_text_selected()) {


### PR DESCRIPTION
Hello. This pull request should make it possible to delete the character following the cursor in a textbox (using the <kbd>Delete</kbd> key on Windows and Linux or the <kbd>Function</kbd> + <kbd>Backspace</kbd> key combination on macOS, although _that_ hasn't been tested).