### PR TITLE
Declare index.html character set

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <meta charset="UTF-8">
         <title>Anim</title>
         <script src="volume-meter.js"></script>
         <script src="jquery-3.2.1.min.js"></script>


### PR DESCRIPTION
Hello. There is no HTML tag declaring the character set for `index.html`. Normally, this doesn't cause any problems because most browsers are smart enough to choose a default encoding based on their language settings, but in some cases might choose the wrong one. This pull request adds a `<meta charset="UTF-8">` tag to `index.html` to prevent this.