### PR TITLE
Update for upstream

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -2,9 +2,9 @@ name: GitHub Pages CD
 
 on:
   push:
-    branches: [ webpack/third-attempt ]
+    branches: [ master ]
   pull_request:
-    branches: [ webpack/third-attempt ]
+    branches: [ master ]
 
   workflow_dispatch:
 

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -3,8 +3,6 @@ name: GitHub Pages CD
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
   workflow_dispatch:
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/supreme-pancakes/anim.git"
+    "url": "git+https://github.com/JonComo/anim.git"
   },
   "keywords": [],
   "author": {
@@ -19,9 +19,9 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/supreme-pancakes/anim/issues"
+    "url": "https://github.com/JonComo/anim/issues"
   },
-  "homepage": "https://github.com/supreme-pancakes/anim/tree/webpack/third-attempt#readme",
+  "homepage": "https://github.com/JonComo/anim#readme",
   "devDependencies": {
     "eslint": "^7.20.0",
     "eslint-config-airbnb-base": "^14.2.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
     "url": "git+https://github.com/supreme-pancakes/anim.git"
   },
   "keywords": [],
-  "author": "",
+  "author": {
+    "name": "JC",
+    "email": "jon@underground.net",
+    "url": "http://joncomo.com"
+  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/supreme-pancakes/anim/issues"


### PR DESCRIPTION
Hello. This pull request should use the `master` branch for the GitHub Pages workflow and should also update the `repository`, `bugs` and `homepage` URL fields in `package.json`. Additionally, it fills out the `author` field, but I can remove that if it's inconvenient.