### PR TITLE
Separate webpack development and production configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "start": "webpack serve --open --config webpack.dev.js",
-    "build": "webpack"
+    "build": "webpack --config webpack.prod.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Quick JS program for creating animations.",
   "private": true,
   "scripts": {
-    "start": "webpack serve",
+    "start": "webpack serve --open --config webpack.dev.js",
     "build": "webpack"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "eslint-plugin-import": "^2.22.1",
     "webpack": "^5.24.2",
     "webpack-cli": "^4.5.0",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^3.11.2",
+    "webpack-merge": "^5.7.3"
   },
   "dependencies": {
     "file-saver": "^2.0.5",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,0 +1,9 @@
+const path = require('path');
+
+module.exports = {
+  entry: path.resolve(__dirname, 'src', 'index.js'),
+  output: {
+    filename: 'main.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+};

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,0 +1,13 @@
+const path = require('path');
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common');
+
+module.exports = merge(common, {
+  mode: 'development',
+  devtool: 'inline-source-map',
+  devServer: {
+    contentBase: path.join(__dirname, 'dist'),
+    compress: true,
+    port: 9000,
+  },
+});

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,0 +1,7 @@
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common');
+
+module.exports = merge(common, {
+  mode: 'production',
+  devtool: 'source-map',
+});


### PR DESCRIPTION
Hello. This pull request should split up the Webpack development and production configurations (`webpack.dev.js` and `webpack.prod.js`, respectively) while keeping a common configuration file (`webpack.common.js`). This way, different optimisations can be used for each.