### PR TITLE
Use older version of Math.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -944,9 +944,9 @@
       "dev": true
     },
     "complex.js": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.11.tgz",
-      "integrity": "sha512-6IArJLApNtdg1P1dFtn3dnyzoZBEF0MwMnrfF1exSBRpZYoy4yieMkpZhQDC0uwctw48vii0CFVyHfpgZ/DfGw=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.4.tgz",
+      "integrity": "sha512-Syl95HpxUTS0QjwNxencZsKukgh1zdS9uXeXX2Us0pHaqBR6kiZZi0AkZ9VpZFwHJyVIUVzI4EumjWdXP3fy6w=="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -1101,9 +1101,9 @@
       "dev": true
     },
     "decimal.js": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-9.0.1.tgz",
+      "integrity": "sha512-2h0iKbJwnImBk4TGk7CG1xadoA0g3LDPlQhQzbZ221zvG0p2YVUedbKIPsOZXKZGx6YmZMJKYOalpCMxSdDqTQ=="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -2223,9 +2223,9 @@
       "dev": true
     },
     "fraction.js": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.13.tgz",
-      "integrity": "sha512-E1fz2Xs9ltlUp+qbiyx9wmt2n9dRzPsS11Jtdb8D2o+cC7wr9xkkKsVKJuBX0ST+LVS+LhLO+SbLJNtfWcJvXA=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.4.tgz",
+      "integrity": "sha512-aK/oGatyYLTtXRHjfEsytX5fieeR5H4s8sLorzcT12taFS+dbMZejnvm9gRa8mZAPwci24ucjq9epDyaq5u8Iw=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -3048,18 +3048,18 @@
       }
     },
     "mathjs": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-9.2.0.tgz",
-      "integrity": "sha512-R2fQxaOmyifxgP4+c59dnfLwpKI1KYHdnT5lLwDuHIZvgyGb71M8ay6kTJTEv9rG04pduqvX4tbBUoG5ypTF8A==",
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-3.20.2.tgz",
+      "integrity": "sha512-3f6/+uf1cUtIz1rYFz775wekl/UEDSQ3mU6xdxW7qzpvvhc2v28i3UtLsGTRB+u8OqDWoSX6Dz8gehaGFs6tCA==",
       "requires": {
-        "complex.js": "^2.0.11",
-        "decimal.js": "^10.2.1",
-        "escape-latex": "^1.2.0",
-        "fraction.js": "^4.0.13",
-        "javascript-natural-sort": "^0.7.1",
-        "seedrandom": "^3.0.5",
-        "tiny-emitter": "^2.1.0",
-        "typed-function": "^2.0.0"
+        "complex.js": "2.0.4",
+        "decimal.js": "9.0.1",
+        "escape-latex": "^1.0.0",
+        "fraction.js": "4.0.4",
+        "javascript-natural-sort": "0.7.1",
+        "seed-random": "2.2.0",
+        "tiny-emitter": "2.0.2",
+        "typed-function": "0.10.7"
       }
     },
     "media-typer": {
@@ -4077,10 +4077,10 @@
         "ajv-keywords": "^3.5.2"
       }
     },
-    "seedrandom": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
-      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+    "seed-random": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
+      "integrity": "sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ="
     },
     "select-hose": {
       "version": "2.0.0",
@@ -4876,9 +4876,9 @@
       "dev": true
     },
     "tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
+      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow=="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -4972,9 +4972,9 @@
       }
     },
     "typed-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-2.0.0.tgz",
-      "integrity": "sha512-Hhy1Iwo/e4AtLZNK10ewVVcP2UEs408DS35ubP825w/YgSBK1KVLwALvvIG4yX75QJrxjCpcWkzkVRB0BwwYlA=="
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-0.10.7.tgz",
+      "integrity": "sha512-3mlZ5AwRMbLvUKkc8a1TI4RUJUS2H27pmD5q0lHRObgsoWzhDAX01yg82kwSP1FUw922/4Y9ZliIEh0qJZcz+g=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   "dependencies": {
     "file-saver": "^2.0.5",
     "jquery": "^3.5.1",
-    "mathjs": "^9.2.0"
+    "mathjs": "^3.10.0"
   }
 }


### PR DESCRIPTION
This pull request should update `package.json` so that NPM installs a Math.js version without breaking changes from 3.10.0. This should fix some bugs in the code, specifically #22.