### PR TITLE
Resolve 'fs' import to empty module

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -202,3 +202,27 @@ Apache License
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+For ccapture.js-npmfixed:
+
+The MIT License
+
+Copyright (c) 2012 Jaume Sanchez Elias
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -5,6 +5,11 @@ module.exports = {
   entry: {
     main: path.resolve(__dirname, 'src', 'index.js'),
   },
+  resolve: {
+    fallback: {
+      fs: false,
+    },
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
Hello. This pull request should resolve `fs` to an empty module so that `ccapture.js-npmfixed` can be successfully bundled. It also adds `ccapture.js-npmfixed`'s license to `LICENSE`.