### PR TITLE
Initialise properties as 'undefined' instead of 'null'

### DIFF
--- a/src/resources.js
+++ b/src/resources.js
@@ -56,21 +56,21 @@ export const rtv = {
     text: 0,
   },
 
-  c: null,
-  ctx: null,
-  formula_text: null,
+  c: undefined,
+  ctx: undefined,
+  formula_text: undefined,
 
-  animator: null,
-  transition: null,
+  animator: undefined,
+  transition: undefined,
   objs: [],
   selected_objs: [],
-  frames: null,
-  menu: null,
-  cam: null,
-  pen: null,
+  frames: undefined,
+  menu: undefined,
+  cam: undefined,
+  pen: undefined,
   num_frames: 3,
   frame: 1, // current frame
-  next_frame: null,
+  next_frame: undefined,
   rendering: false,
   presenting: false,
   debug: false,
@@ -78,8 +78,8 @@ export const rtv = {
 
   // speech synthesis
   speech: {
-    synth: null,
-    voices: null,
+    synth: undefined,
+    voices: undefined,
   },
 
   t_ease: 0,
@@ -88,8 +88,8 @@ export const rtv = {
 
   tool: 'select',
   selecting: false,
-  new_line: null,
-  text_copied: null,
+  new_line: undefined,
+  text_copied: undefined,
 
   keys: {
     tab: false,


### PR DESCRIPTION
Hello. I realised that when I created `src/resources.js`, I initialised some properties of `rtv` as `null`. This might cause a problem if a condition like `rtx.prop !== undefined` is used to check if a property was already assigned to. Since `null !== undefined`, this might introduce some bugs into the code. Technically, initialising the properties of `rtv` as `undefined` is unnecessary, but I did it to make it easier to identify different properties that would later be used in the code.