### PR TITLE
Prevent event default in transformProps

### DIFF
--- a/src/graphics/camera.js
+++ b/src/graphics/camera.js
@@ -138,8 +138,7 @@ export default function Camera() {
       return;
     }
 
-    const { key } = evt;
-    this.properties[rtv.frame] = transformProps(key, this.properties[rtv.frame], 0.01);
+    this.properties[rtv.frame] = transformProps(evt, this.properties[rtv.frame], 0.01);
   };
 
   this.update_props = () => {

--- a/src/index.js
+++ b/src/index.js
@@ -896,24 +896,22 @@ export function hexToRgb(hex) {
   ] : null;
 }
 
-export function transformProps(key, props, step = 0.2) {
-  const propsL = { ...props };
+export function transformProps({ key, preventDefault }, props, step = 0.2) {
+  const transformations = {
+    l: (p) => ({ ...p, w: p.w + 1 }),
+    j: (p) => ({ ...p, w: p.w - 1 }),
+    i: (p) => ({ ...p, w: p.h + 1 }),
+    k: (p) => ({ ...p, w: p.h - 1 }),
+    u: (p) => ({ ...p, w: p.r - Math.PI / 12 }),
+    o: (p) => ({ ...p, w: p.r + Math.PI / 12 }),
+  };
 
-  if (key === 'l') {
-    propsL.w += step;
-  } else if (key === 'j') {
-    propsL.w -= step;
-  } else if (key === 'i') {
-    propsL.h += step;
-  } else if (key === 'k') {
-    propsL.h -= step;
-  } else if (key === 'u') {
-    propsL.r -= Math.PI / 12;
-  } else if (key === 'o') {
-    propsL.r += Math.PI / 12;
+  if (key in transformations) {
+    preventDefault();
+    return transformations[key](props);
   }
 
-  return propsL;
+  return props;
 }
 
 export function constrain(v) {

--- a/src/tools/circle.js
+++ b/src/tools/circle.js
@@ -140,7 +140,7 @@ export default function Circle(color, pos) {
         p.a_e += step;
       }
     } else {
-      this.properties[rtv.frame] = transformProps(key, this.properties[rtv.frame]);
+      this.properties[rtv.frame] = transformProps(evt, this.properties[rtv.frame]);
     }
 
     return false;

--- a/src/tools/shape.js
+++ b/src/tools/shape.js
@@ -147,10 +147,8 @@ export default function Shape(color, path) {
   };
 
   this.onkeydown = (evt) => {
-    const { key } = evt;
-
     if (this.selected_indices.length !== 0) {
-      this.properties[rtv.frame] = transformProps(key, this.properties[rtv.frame]);
+      this.properties[rtv.frame] = transformProps(evt, this.properties[rtv.frame]);
     }
 
     return false;

--- a/src/tools/text.js
+++ b/src/tools/text.js
@@ -347,10 +347,7 @@ export default function Text(text, pos) {
         }
       }
 
-      this.properties[rtv.frame] = transformProps(
-        key,
-        this.properties[rtv.frame],
-      );
+      this.properties[rtv.frame] = transformProps(evt, this.properties[rtv.frame]);
 
       return true;
     }


### PR DESCRIPTION
Hello. This pull request makes `transformProps` call `preventDefault` on an event passed in when it's able to handle the key. This should, for example, prevent the browser from handling key presses like <kbd>ctrl</kbd> + <kbd>l</kbd>, which should scale an object instead of selecting the text in the URL bar.
