### PR TITLE
Fix GitHub CLI fork instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ First things first, you must download `anim`'s code. Here are some options:
 
   If you're going to submit code changes to this repository, then you should create a fork of it. To do so, navigate to this repository's URL (https://github.com/JonComo/anim) and press the <kbd>Fork</kbd> button in the top-right corner of the GitHub UI. Then, clone it using `git clone https://github.com/<your username here>/anim` or whatever software you please!
 
-  - Fork with GitHub CLI
+  - Fork with the GitHub CLI
 
     To fork this repo and then clone the fork with the [GitHub CLI](https://cli.github.com/), run `gh repo fork --clone JonComo/`.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ First things first, you must download `anim`'s code. Here are some options:
 
   - Fork with the GitHub CLI
 
-    To fork this repo and then clone the fork with the [GitHub CLI](https://cli.github.com/), run `gh repo fork --clone JonComo/`.
+    To fork this repo and then clone the fork with the [GitHub CLI](https://cli.github.com/), run `gh repo fork --clone JonComo/anim`.
 
 - Download https://github.com/JonComo/anim/archive/master.zip and unzip it.
 


### PR DESCRIPTION
Hello. This pull request adds a "the" so that "Fork with GitHub CLI" reads "Fork with the GitHub CLI". It also fixes the mistake in the fork command, changing `JonComo/` to `JonComo/anim`.