### PR TITLE
Do not deselect when shift is pressed

### DIFF
--- a/src/tools/text.js
+++ b/src/tools/text.js
@@ -483,7 +483,7 @@ export default function Text(text, pos) {
       }
     }
 
-    if (!rtv.keys.shift || (key !== 'ArrowRight' && key !== 'ArrowLeft')) {
+    if (!rtv.keys.shift || (key !== 'Shift' && key !== 'ArrowRight' && key !== 'ArrowLeft')) {
       this.cursor_selection = this.cursor;
     }
 


### PR DESCRIPTION
When `shift` is pressed while a selection exists in a textbox, it resets `cursor_selection` to `cursor`. This pull request allows the user to continue modifying the selection instead.