### PR TITLE
Add another anonymous function syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anim",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Quick JS program for creating animations.",
   "private": true,
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -218,17 +218,6 @@ function rgb1ToHex(a) {
   return rgbToHex(c);
 }
 
-// http://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
-export function guid() {
-  function s4() {
-    return Math.floor((1 + Math.random()) * 0x10000)
-      .toString(16)
-      .substring(1);
-  }
-  return `${s4() + s4()}-${s4()}-${s4()}-${
-    s4()}-${s4()}${s4()}${s4()}`;
-}
-
 export function prettyRound(num) {
   return (Math.round(num * 100) / 100).toFixed(2);
 }
@@ -1025,8 +1014,6 @@ function textArrayToObjs(arr, keepAnimation) {
       newObj.properties[rtv.frame] = o.properties[1];
       newObj.select();
     }
-
-    newObj.guid = o.guid;
 
     newObjs.push(newObj);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1004,18 +1004,6 @@ export function interpolate(a, b) {
   return interp;
 }
 
-export function guidIndex(objs, obj) {
-  const N = objs.length;
-  for (let i = 0; i < N; i++) {
-    const tobj = objs[i];
-    if (tobj.guid === obj.guid) {
-      return i;
-    }
-  }
-
-  return -1;
-}
-
 function textArrayToObjs(arr, keepAnimation) {
   const newObjs = [];
   for (let i = 0; i < arr.length; i++) {

--- a/src/tools/circle.js
+++ b/src/tools/circle.js
@@ -1,7 +1,6 @@
 import {
   copy,
   distance,
-  guid,
   interpolate,
   rgbToHex,
   transformProps,
@@ -15,7 +14,6 @@ import {
 
 export default function Circle(color, pos) {
   this.type = 'Circle';
-  this.guid = guid();
   this.properties = {};
   this.properties[rtv.frame] = {
     p: pos, c: color, fill: [0, 0, 0, 0], a_s: 0, a_e: Math.PI * 2.0, w: 1, h: 1, r: 0,

--- a/src/tools/network.js
+++ b/src/tools/network.js
@@ -1,7 +1,6 @@
 import {
   copy,
   distance,
-  guid,
   interpolate,
 } from '../index';
 import {
@@ -13,7 +12,6 @@ import {
 
 export default function Network(position) {
   this.type = 'Network';
-  this.guid = guid();
   this.properties = {};
   this.properties[rtv.frame] = {
     layers: [2, 3, 2], p: position, c: [0, 0, 0, 1], w: 1, h: 1, r: 0,

--- a/src/tools/shape.js
+++ b/src/tools/shape.js
@@ -2,7 +2,6 @@ import {
   between,
   copy,
   distance,
-  guid,
   interpolate,
   rgbToHex,
   transformProps,
@@ -16,7 +15,6 @@ import {
 
 export default function Shape(color, path) {
   this.type = 'Shape';
-  this.guid = guid();
   this.properties = {};
   this.properties[rtv.frame] = {
     c: color, path, v: false, w: 1, h: 1, r: 0,

--- a/src/tools/text.js
+++ b/src/tools/text.js
@@ -869,11 +869,10 @@ export default function Text(text, pos) {
 
     let parsedText = unparsedText;
 
-    // replace @ with anonymous fn name
     if (parsedText && parsedText.length) {
       parsedText = parsedText
-        .replace(/@/g, '_anon')
-        .replace(/([^(]*)(\|->|↦)/g, (match, parameters) => `_anon(${parameters}) = `);
+        .replace(/([^(]*)(\|->|↦)/g, (match, parameters) => `@(${parameters}) = `)
+        .replace(/@/g, '_anon'); // Replace @ with anonymous fn name
     }
 
     if (parsedText && parsedText.includes(':')) {

--- a/src/tools/text.js
+++ b/src/tools/text.js
@@ -871,7 +871,7 @@ export default function Text(text, pos) {
 
     if (parsedText && parsedText.length) {
       parsedText = parsedText
-        .replace(/([^(]*)(\|->|↦)/g, (match, parameters) => `@(${parameters}) = `)
+        .replace(/([^(]*)(\|->|↦)/g, (match, parameters) => `@(${parameters})=`)
         .replace(/@/g, '_anon'); // Replace @ with anonymous fn name
     }
 

--- a/src/tools/text.js
+++ b/src/tools/text.js
@@ -10,7 +10,6 @@ import {
   enterSelect,
   formatMatrix,
   guid,
-  guidIndex,
   interpolate,
   matrixSize,
   prettyRound,

--- a/src/tools/text.js
+++ b/src/tools/text.js
@@ -9,7 +9,6 @@ import {
   drawSimple,
   enterSelect,
   formatMatrix,
-  guid,
   interpolate,
   matrixSize,
   prettyRound,
@@ -44,7 +43,6 @@ function getSortedTexts() {
 
 export default function Text(text, pos) {
   this.type = 'Text';
-  this.guid = guid();
   this.properties = {};
   this.properties[rtv.frame] = {
     t: text,

--- a/src/tools/text.js
+++ b/src/tools/text.js
@@ -872,8 +872,8 @@ export default function Text(text, pos) {
     // replace @ with anonymous fn name
     if (parsedText && parsedText.length) {
       parsedText = parsedText
-        .replace(/@/g, '_anon_')
-        .replace(/([^(]*)(\|->|↦)/g, (match, parameters) => `_anon_(${parameters}) = `);
+        .replace(/@/g, '_anon')
+        .replace(/([^(]*)(\|->|↦)/g, (match, parameters) => `_anon(${parameters}) = `);
     }
 
     if (parsedText && parsedText.includes(':')) {

--- a/src/tools/text.js
+++ b/src/tools/text.js
@@ -873,14 +873,9 @@ export default function Text(text, pos) {
 
     // replace @ with anonymous fn name
     if (parsedText && parsedText.length) {
-      const split = parsedText.split('@');
-      let newT = '';
-      const N = split.length;
-      for (let i = 0; i < N - 1; i++) {
-        newT += `${split[i]}anon${guid().slice(0, 8)}`;
-      }
-      newT += split[N - 1];
-      parsedText = newT;
+      parsedText = parsedText
+        .replace(/@/g, '_anon_')
+        .replace(/([^(]*)(\|->|↦)/g, (match, parameters) => `_anon_(${parameters}) = `);
     }
 
     if (parsedText && parsedText.includes(':')) {


### PR DESCRIPTION
Hello. This pull request adds the possibility to create almost-anonymous functions using the text `|->` or the unicode maplet symbol `↦`. It also refactors the code that replaces `@` with an anonymous function name. Here's a screenshot (note that the syntax with the maplet symbol doesn't actually need any parameters on the left side):

![falmost-anonymous functions demo](https://user-images.githubusercontent.com/49883288/112702502-18e0df00-8e6a-11eb-9e12-af584f37d129.png)

Note that the functions generated aren't really anonymous since the `@` symbol is just replaced by `_anon` (I don't think that name will be used very often :smirk:) and the maplet syntax just wraps the `@` syntax. The `guid` and `guidIndex` function definitions and related code are also removed in this pull request since they are not used anywhere any more.