### PR TITLE
fillRect background

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anim",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Quick JS program for creating animations.",
   "private": true,
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -3660,7 +3660,7 @@ math.import({
  * @param {CanvasRenderingContext2D} ctx Canvas context.
  * @param {string} color Background color.
  */
-function drawBackground(ctx, color) {
+function drawBackground(ctx = rtv.ctx, color = CANVAS_BG) {
   ctx.save(); // Save canvas state
   ctx.fillStyle = color; // Set fill style to requested background color
   ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height); // Draw filled rectangle to cover surface
@@ -4175,7 +4175,7 @@ window.addEventListener('load', () => {
     }
 
     if (!parser.get('_trace')) {
-      drawBackground(rtv.ctx, CANVAS_BG);
+      drawBackground();
     }
 
     rtv.cam.update_props();

--- a/src/index.js
+++ b/src/index.js
@@ -3656,13 +3656,12 @@ math.import({
 });
 
 /**
- * Draws a solid background.
+ * Draws a colored rectangle that covers the canvas.
  * @param {CanvasRenderingContext2D} ctx Canvas context.
  * @param {string} color Background color.
  */
 function drawBackground(ctx, color) {
   ctx.save(); // Save canvas state
-  ctx.globalCompositeOperation = 'destination-over'; // Draw underneath existing content
   ctx.fillStyle = color; // Set fill style to requested background color
   ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height); // Draw filled rectangle to cover surface
   ctx.restore(); // Restore canvas state
@@ -4176,7 +4175,7 @@ window.addEventListener('load', () => {
     }
 
     if (!parser.get('_trace')) {
-      rtv.ctx.clearRect(0, 0, rtv.c.width, rtv.c.height);
+      drawBackground(rtv.ctx, CANVAS_BG);
     }
 
     rtv.cam.update_props();
@@ -4266,11 +4265,6 @@ window.addEventListener('load', () => {
     rtv.transition.update();
 
     rtv.t += 1;
-
-    // Draw background only if recording to speed up 'animate'
-    if (rtv.recordingManager.recording !== undefined) {
-      drawBackground(rtv.ctx, CANVAS_BG);
-    }
 
     requestAnimationFrame(animate);
   }


### PR DESCRIPTION
Hello. Right now, the canvas is cleared every frame and a background is additionally drawn if recording. This pull request draws a solid background instead (it's only ~1ms more at 60fps on an 800x600 pixel canvas for me) of clearing. This also speeds up recording and makes `_trace = true` work while recording.