### PR TITLE
Warn on prefer-destructuring

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,6 @@ module.exports = {
   rules: {
     'no-plusplus': 'off',
     'no-underscore-dangle': 'off',
-    'prefer-destructuring': 'off',
+    'prefer-destructuring': 'warn',
   },
 };


### PR DESCRIPTION
This pull request configures ESLint to warn on `prefer-destructuring` instead of being silent. It will also allow it to fix anything possible related to destructuring.
