### PR TITLE
Fix sliders

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anim",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Quick JS program for creating animations.",
   "private": true,
   "scripts": {

--- a/src/tools/text.js
+++ b/src/tools/text.js
@@ -615,14 +615,18 @@ export default function Text(text, pos) {
         }
       }
     } catch (e) {
+      const trimmedStack = e.stack.substring(0,
+        e.stack.search(/(at Text.eval \(|^Text\/this.eval@)/m));
       const lastError = this.properties[rtv.frame].e;
 
       if (
         lastError === undefined
         || lastError.message !== e.message
         || lastError.name !== e.name
+        || lastError.trimmedStack !== trimmedStack
       ) {
-        console.error('eval error: ', e);
+        console.error('eval error: ', e.stack);
+        e.trimmedStack = trimmedStack;
         this.properties[rtv.frame].e = e;
       }
     }

--- a/src/tools/text.js
+++ b/src/tools/text.js
@@ -51,7 +51,7 @@ export default function Text(text, pos) {
     w: 1,
     h: 1,
     r: 0,
-    i: false,
+    e: undefined,
   };
 
   // ephemeral
@@ -123,7 +123,7 @@ export default function Text(text, pos) {
       this.properties[rtv.frame].t = t.slice(0, this.cursor)
         + copiedText
         + t.slice(this.cursor, t.length);
-      this.properties[rtv.frame].i = false;
+      this.properties[rtv.frame].i = undefined;
       this.cursor += copiedText.length;
       this.cursor_selection = this.cursor;
     }
@@ -574,50 +574,56 @@ export default function Text(text, pos) {
       }
     }
 
-    if (!this.properties[rtv.frame].i) {
-      try {
-        parser.set('text_props', i);
+    try {
+      parser.set('text_props', i);
 
-        const val = this.cargs[0].evaluate(parser.scope);
+      const val = this.cargs[0].evaluate(parser.scope);
 
-        // only display the value if its not an assignment or constant
-        const opType = math.parse(this.args[0]).type;
+      // only display the value if its not an assignment or constant
+      const opType = math.parse(this.args[0]).type;
 
-        if (!opType.includes('Assignment') && opType !== 'ConstantNode') {
-          const type = typeof val;
+      if (!opType.includes('Assignment') && opType !== 'ConstantNode') {
+        const type = typeof val;
 
-          // set display text
-          if (type === 'number') {
+        // set display text
+        if (type === 'number') {
+          if (rtv.keys.ctrl) {
+            // nothing
+            this.text_val = `=${val}`;
+          } else {
+            this.text_val = `=${prettyRound(val)}`;
+          }
+        } else if (type === 'boolean') {
+          this.text_val = ` = ${val}`;
+        } else if (type === 'object' && val._data && val._data.length !== 0) {
+          // prob a matrix, render entries
+          this.matrix_vals = val._data;
+          this.text_val = null;
+        } else if (val && 're' in val && val.im) {
+          if (val) {
             if (rtv.keys.ctrl) {
               // nothing
               this.text_val = `=${val}`;
             } else {
-              this.text_val = `=${prettyRound(val)}`;
+              this.text_val = `=${prettyRound(
+                val.re,
+              ).toString()} + ${prettyRound(val.im).toString()}i`;
             }
-          } else if (type === 'boolean') {
-            this.text_val = ` = ${val}`;
-          } else if (type === 'object' && val._data && val._data.length !== 0) {
-            // prob a matrix, render entries
-            this.matrix_vals = val._data;
-            this.text_val = null;
-          } else if (val && 're' in val && val.im) {
-            if (val) {
-              if (rtv.keys.ctrl) {
-                // nothing
-                this.text_val = `=${val}`;
-              } else {
-                this.text_val = `=${prettyRound(
-                  val.re,
-                ).toString()} + ${prettyRound(val.im).toString()}i`;
-              }
-            }
-          } else if (val) {
-            this.text_val = `=${val.toString()}`;
           }
+        } else if (val) {
+          this.text_val = `=${val.toString()}`;
         }
-      } catch (e) {
+      }
+    } catch (e) {
+      const lastError = this.properties[rtv.frame].e;
+
+      if (
+        lastError === undefined
+        || lastError.message !== e.message
+        || lastError.name !== e.name
+      ) {
         console.error('eval error: ', e);
-        this.properties[rtv.frame].i = true;
+        this.properties[rtv.frame].e = e;
       }
     }
 
@@ -628,7 +634,7 @@ export default function Text(text, pos) {
     const changed = this.properties[rtv.frame].t !== newText;
 
     this.properties[rtv.frame].t = newText;
-    this.properties[rtv.frame].i = false;
+    this.properties[rtv.frame].i = undefined;
     this.constrain_cursors();
 
     if (changed) {


### PR DESCRIPTION
Hello. This pull request fixes the issue with sliders not working. The issue occurred because textboxes were not re-evaluated when slid. Additionally, any textbox using the variable set in the slider would not be reloaded. To fix this, the name, message and stack of each error is kept to be checked against. The stack is not that reliable since its format varies from browser to browser. I've gotten it to work in Firefox and Chromium for now, and it should never fail since `String.prototype.search` returns -1, thus two empty strings will be compared.