### PR TITLE
Fix no-restricted-syntax

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,6 @@ module.exports = {
     'no-nested-ternary': 'warn',
     'no-plusplus': 'off',
     'no-restricted-globals': 'warn',
-    'no-restricted-syntax': 'warn',
     'no-shadow': 'warn',
     'no-underscore-dangle': 'off',
     'no-unused-vars': 'warn',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anim",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Quick JS program for creating animations.",
   "private": true,
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -937,7 +937,7 @@ export function interpolate(a, b) {
   }
 
   const interp = {};
-  for (const key in a) {
+  Object.keys(a).forEach((key) => {
     if (key === 'p') {
       // interpolate position
       const ap = a[key];
@@ -988,7 +988,7 @@ export function interpolate(a, b) {
     } else {
       interp[key] = a[key];
     }
-  }
+  });
 
   return interp;
 }


### PR DESCRIPTION
Hello. This pull request uses `Object.keys` and `Array.prototype.forEach` instead of the for...in loop in `src/index.js`. This should resolve the ESLint `no-restricted-syntax` warning.
