### PR TITLE
Fix no-empty

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,6 @@ module.exports = {
     'consistent-return': 'warn',
     'import/no-cycle': 'warn',
     'no-bitwise': 'warn',
-    'no-empty': 'warn',
     'no-eval': 'warn',
     'no-mixed-operators': 'warn',
     'no-nested-ternary': 'warn',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "anim",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -681,7 +681,7 @@ export function drawFn(fn) {
     try {
       tree = math.parse(fn);
     } catch (e) {
-
+      // Continue
     }
 
     if (tree) {
@@ -3909,7 +3909,7 @@ window.addEventListener('load', () => {
     try {
       math.compile('click()').evaluate(parser.scope);
     } catch (e) {
-
+      // Continue
     }
 
     if (rtv.cam.mouse_down(evt)) {

--- a/src/index.js
+++ b/src/index.js
@@ -680,9 +680,7 @@ export function drawFn(fn) {
   } else {
     try {
       tree = math.parse(fn);
-    } catch {
-      // Continue
-    }
+    } catch { /* Continue */ }
 
     if (tree) {
       cacheFn[fn] = tree;
@@ -3908,9 +3906,7 @@ window.addEventListener('load', () => {
 
     try {
       math.compile('click()').evaluate(parser.scope);
-    } catch {
-      // Continue
-    }
+    } catch { /* Continue */ }
 
     if (rtv.cam.mouse_down(evt)) {
       return;

--- a/src/index.js
+++ b/src/index.js
@@ -680,7 +680,7 @@ export function drawFn(fn) {
   } else {
     try {
       tree = math.parse(fn);
-    } catch (e) {
+    } catch {
       // Continue
     }
 
@@ -3908,7 +3908,7 @@ window.addEventListener('load', () => {
 
     try {
       math.compile('click()').evaluate(parser.scope);
-    } catch (e) {
+    } catch {
       // Continue
     }
 


### PR DESCRIPTION
Hello. This pull request fixes the ESLint `no-empty` warnings by adding a comment in the empty bodies to explain that they are empty purposely (for example, try..catch blocks without  anything in the catch block).