### PR TITLE
Fix math.logicTable P and Q substition

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1428,9 +1428,9 @@ math.import({
         for (let j = 0; j < 2; j++) {
           const q = O[j];
 
-          s.replace('P', p);
-          s.replace('Q', q);
-          const r = math.beval(s);
+          const r = math.beval(s
+            .replace('P', p)
+            .replace('Q', q));
 
           if (r) {
             rtv.ctx.fillStyle = COLORS[4];


### PR DESCRIPTION
Hello. This pull request should fix the `math.logicTable` function by passing in expressions with replaced 'P's and 'Q's into `math.beval`. This is necessary since `String.prototype.replace` doesn't actually mutate the original string itself but instead returns another.
