### PR TITLE
Fix no-nested-ternary

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,6 @@ module.exports = {
     'no-bitwise': 'warn',
     'no-eval': 'warn',
     'no-mixed-operators': 'warn',
-    'no-nested-ternary': 'warn',
     'no-plusplus': 'off',
     'no-shadow': 'warn',
     'no-underscore-dangle': 'off',

--- a/src/index.js
+++ b/src/index.js
@@ -1787,7 +1787,7 @@ math.import({
 
       indices
         .map((i) => camData[i][2])
-        .sort((a, b) => (a < b ? 1 : (a > b ? -1 : 1)));
+        .sort((a, b) => (a <= b ? 1 : -1));
 
       let col;
       for (let j = 0; j < n; j++) {


### PR DESCRIPTION
Hello. This pull request resolves the ESLint `no-nested-ternary` warning in `src/index.js` by rewriting the nested ternary statements.
