### PR TITLE
Evaluate textboxes on click in presentation mode

### DIFF
--- a/src/tools/text.js
+++ b/src/tools/text.js
@@ -788,12 +788,17 @@ export default function Text(text, pos) {
 
     if (this.near_mouse) {
       if (!this.dragged) {
-        this.select();
+        if (rtv.presenting) {
+          this.eval();
+        } else {
+          this.select();
 
-        // move cursor
-        this.cursor = this.char_index_at_x(rtv.mouse.pos.x);
-        this.cursor_selection = this.cursor;
-        this.constrain_cursors();
+          // move cursor
+          this.cursor = this.char_index_at_x(rtv.mouse.pos.x);
+          this.cursor_selection = this.cursor;
+          this.constrain_cursors();
+        }
+
         return true;
       }
     } else if (!rtv.keys.shift && this.is_selected()) {


### PR DESCRIPTION
Hello. This pull request adds a clause to the `Text` class's `keyup` listeners such that they are re-evaluated in presentation mode when clicked on.