### PR TITLE
Allow specification of textbox requirements and fulfillments

### DIFF
--- a/src/tools/text.js
+++ b/src/tools/text.js
@@ -878,9 +878,18 @@ export default function Text(text, pos) {
     let parsedText = unparsedText;
 
     if (parsedText && parsedText.length) {
+      this.requirements = [];
+      this.fulfillments = [];
+
       parsedText = parsedText
         .replace(/([^(]*)(\|->|↦)/g, (match, parameters) => `@(${parameters})=`)
-        .replace(/@/g, '_anon'); // Replace @ with anonymous fn name
+        .replace(/@/g, '_anon') // Replace @ with anonymous fn name
+        .replace(/^{(.*?)}(.*){(.*?)}$/, (match, requirements, expression, fulfillments) => {
+          this.requirements = requirements.split(' ');
+          this.fulfillments = fulfillments.split(' ');
+
+          return expression;
+        });
     }
 
     if (parsedText && parsedText.includes(':')) {


### PR DESCRIPTION
Hello. This pull request adds a `String.prototype.replace` call in the `Text.prototype.parse_text` method that assigns the `.requirements` and `.fulfillments` properties on a `Text` instance to match the ones specified in the contents of the textbox. The requirements can be specified by prepending the text with a space-separated list of variable names surrounded with curly braces (`{foo bar baz}...`) while the fulfillments can be specified by appending the text with a space-separated list of variable names surrounded with curly braces (`...{foo bar baz}`).