### PR TITLE
Emit and Handle Assignment Events

### DIFF
--- a/src/graphics/transition.js
+++ b/src/graphics/transition.js
@@ -26,9 +26,9 @@ export default function Transition() {
       this.step += 1;
       rtv.t_percent = this.step / this.steps;
       rtv.t_in_out = -math.cos(rtv.t_percent * 2 * math.PI - math.PI) / 2 + 0.5;
-      parser.set('_t', rtv.t_percent);
+      Text.setVariable('_t', rtv.t_percent);
       rtv.t_ease = easeInOut(rtv.t_percent);
-      parser.set('_tt', rtv.t_ease);
+      Text.setVariable('_tt', rtv.t_ease);
       rtv.t_ease = sigmoid(rtv.t_percent, 1.2, -0.4, 14) - sigmoid(rtv.t_percent, 0.2, -0.6, 15);
       if (this.step >= this.steps) {
         rtv.t_percent = 1.0;

--- a/src/graphics/transition.js
+++ b/src/graphics/transition.js
@@ -1,5 +1,6 @@
 import { easeInOut, sigmoid } from '../index';
-import { math, parser, rtv } from '../resources';
+import { math, rtv } from '../resources';
+import Text from '../tools/text';
 
 export default function Transition() {
   this.steps = 0;

--- a/src/index.js
+++ b/src/index.js
@@ -1302,7 +1302,7 @@ export function transitionWithNext(next) {
 
     rtv.objs.forEach((obj) => {
       if (obj instanceof Text) {
-        obj.parse_text(obj.properties[rtv.frame].t);
+        obj.parse_text();
         obj.eval();
       }
     });

--- a/src/index.js
+++ b/src/index.js
@@ -1301,8 +1301,9 @@ export function transitionWithNext(next) {
     rtv.frame = targ;
 
     rtv.objs.forEach((obj) => {
-      if (typeof obj.parse_text === 'function') {
+      if (obj instanceof Text) {
         obj.parse_text(obj.properties[rtv.frame].t);
+        obj.eval();
       }
     });
     Text.setVariable('frame', rtv.frame);

--- a/src/index.js
+++ b/src/index.js
@@ -1306,7 +1306,6 @@ export function transitionWithNext(next) {
         obj.eval();
       }
     });
-    Text.setVariable('frame', rtv.frame);
   });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1304,10 +1304,6 @@ export function transitionWithNext(next) {
       if (typeof obj.parse_text === 'function') {
         obj.parse_text(obj.properties[rtv.frame].t);
       }
-
-      if (typeof obj.eval === 'function') {
-        obj.eval();
-      }
     });
     Text.setVariable('frame', rtv.frame);
   });
@@ -4099,13 +4095,6 @@ window.addEventListener('load', () => {
     rtv.ctx.font = FONT.ANIM;
 
     const N = rtv.objs.length;
-    for (let i = 0; i < N; i++) {
-      const obj = rtv.objs[i];
-      if (typeof obj.eval === 'function') {
-        obj.eval();
-      }
-    }
-
     for (let i = 0; i < N; i++) {
       const obj = rtv.objs[i];
       obj.render(rtv.ctx);

--- a/src/index.js
+++ b/src/index.js
@@ -786,14 +786,14 @@ function grad2(c, x, y) {
   // depends on x and y
   const h = 0.0001;
 
-  parser.set('x', x + h);
+  Text.setVariable('x', x + h);
   const fxh = c.evaluate(parser.scope);
-  parser.set('x', x);
+  Text.setVariable('x', x);
   const fx = c.evaluate(parser.scope);
 
-  parser.set('y', y + h);
+  Text.setVariable('y', y + h);
   const fyh = c.evaluate(parser.scope);
-  parser.set('y', y);
+  Text.setVariable('y', y);
   const fy = c.evaluate(parser.scope);
 
   return [(fxh - fx) / h, (fyh - fy) / h];
@@ -1299,7 +1299,6 @@ export function transitionWithNext(next) {
 
   rtv.transition.run(steps, next, (targ) => {
     rtv.frame = targ;
-    parser.set('frame', rtv.frame);
 
     rtv.objs.forEach((obj) => {
       if (typeof obj.parse_text === 'function') {
@@ -1310,6 +1309,7 @@ export function transitionWithNext(next) {
         obj.eval();
       }
     });
+    Text.setVariable('frame', rtv.frame);
   });
 }
 
@@ -2681,10 +2681,10 @@ math.import({
     try {
       parser.evaluate('_trace');
     } catch (e) {
-      parser.set('_trace', false);
+      Text.setVariable('_trace', false);
     }
 
-    parser.set('_trace', !parser.evaluate('_trace'));
+    Text.setVariable('_trace', !parser.evaluate('_trace'));
   },
   drawFarmer() {
     rtv.ctx.save();
@@ -3584,6 +3584,7 @@ function drawBackground(ctx = rtv.ctx, color = CANVAS_BG) {
 
 window.addEventListener('load', () => {
   rtv.objs = [];
+  Text.setVariable('frame', rtv.frame);
 
   rtv.c = document.getElementById('viewport');
   rtv.c.style.backgroundColor = CANVAS_BG;
@@ -3886,8 +3887,8 @@ window.addEventListener('load', () => {
     rtv.mouse.grid = constrainToGrid(rtv.mouse.pos);
     rtv.mouse.graph = rtv.cam.screen_to_graph(rtv.mouse.pos);
 
-    parser.set('_y', rtv.mouse.graph.x);
-    parser.set('_z', rtv.mouse.graph.y);
+    Text.setVariable('_y', rtv.mouse.graph.x);
+    Text.setVariable('_z', rtv.mouse.graph.y);
 
     if (rtv.pen.mouse_move(evt)) {
       return;
@@ -4073,14 +4074,14 @@ window.addEventListener('load', () => {
       rtv.fps = 30; // save power when editing
     }
 
-    parser.set('_frame', rtv.t);
-    parser.set('_millis', rtv.millis);
+    Text.setVariable('_frame', rtv.t);
+    Text.setVariable('_millis', rtv.millis);
     const mp = rtv.cam.screen_to_graph({ x: rtv.mouse.pos.x, y: rtv.mouse.pos.y });
-    parser.set('_mx', mp.x);
-    parser.set('_my', mp.y);
+    Text.setVariable('_mx', mp.x);
+    Text.setVariable('_my', mp.y);
 
     if (rtv.meter) {
-      parser.set('_vol', rtv.meter.volume);
+      Text.setVariable('_vol', rtv.meter.volume);
     }
 
     if (rtv.presenting) {

--- a/src/resources.js
+++ b/src/resources.js
@@ -122,8 +122,5 @@ export const rtv = {
 };
 
 export const math = create(all);
-
 export const parser = math.parser();
-parser.set('frame', rtv.frame);
-
 export const date = new Date();

--- a/src/tools/text.js
+++ b/src/tools/text.js
@@ -575,7 +575,7 @@ export default function Text(text, pos) {
     }
 
     try {
-      parser.set('text_props', i);
+      Text.setVariable('text_props', i);
 
       const val = this.cargs[0].evaluate(parser.scope);
 
@@ -750,7 +750,7 @@ export default function Text(text, pos) {
         this.text_val = `=${roundWithKey(newVal)}`;
 
         try {
-          parser.set(varName, newVal);
+          Text.setVariable(varName, newVal);
         } catch (e) {
           console.error('slide error: ', e);
         }
@@ -1250,3 +1250,10 @@ export default function Text(text, pos) {
 
   this.parse_text();
 }
+
+Text.assignments = new EventTarget();
+
+Text.setVariable = (name, value) => {
+  parser.set(name, value);
+  Text.assignments.dispatchEvent(new Event(name));
+};

--- a/src/tools/text.js
+++ b/src/tools/text.js
@@ -538,7 +538,7 @@ export default function Text(text, pos) {
 
     if (this.new) {
       this.new = false;
-      this.parse_text(this.properties[rtv.frame].t);
+      this.parse_text();
     }
 
     if (!this.cargs[0]) {
@@ -641,7 +641,7 @@ export default function Text(text, pos) {
     this.constrain_cursors();
 
     if (changed) {
-      this.parse_text(newText);
+      this.parse_text();
     }
   };
 
@@ -875,12 +875,12 @@ export default function Text(text, pos) {
     return size;
   };
 
-  this.parse_text = (unparsedText) => {
+  this.parse_text = () => {
     this.command = '';
     this.args = [];
     this.cargs = [];
 
-    let parsedText = unparsedText;
+    let parsedText = this.properties[rtv.frame].t;
 
     if (parsedText && parsedText.length) {
       this.requirements = [];
@@ -1248,5 +1248,5 @@ export default function Text(text, pos) {
     return js;
   };
 
-  this.parse_text(text);
+  this.parse_text();
 }

--- a/src/tools/text.js
+++ b/src/tools/text.js
@@ -65,6 +65,7 @@ export default function Text(text, pos) {
   this.near_mouse = false;
   this.size = { w: 0, h: 0 }; // pixel width and height
   this.image = null;
+  this.dirty = false;
 
   this.select = () => {
     this.selected = true;
@@ -533,6 +534,7 @@ export default function Text(text, pos) {
       return;
     }
 
+    this.dirty = true;
     this.text_val = '';
     this.matrix_vals = [];
 
@@ -614,6 +616,10 @@ export default function Text(text, pos) {
           this.text_val = `=${val.toString()}`;
         }
       }
+
+      this.fulfillments.forEach((f) => {
+        Text.assignments.dispatchEvent(new Event(f));
+      });
     } catch (e) {
       const trimmedStack = e.stack.substring(0,
         e.stack.search(/(at Text.eval \(|^Text\/this.eval@)/m));
@@ -875,26 +881,45 @@ export default function Text(text, pos) {
     return size;
   };
 
+  this.handleAssignment = () => {
+    if (!this.dirty) this.eval();
+  };
+
   this.parse_text = () => {
     this.command = '';
     this.args = [];
     this.cargs = [];
+    this.dirty = false;
 
     let parsedText = this.properties[rtv.frame].t;
 
     if (parsedText && parsedText.length) {
-      this.requirements = [];
+      let newRequirements = [];
       this.fulfillments = [];
 
       parsedText = parsedText
         .replace(/([^(]*)(\|->|↦)/g, (match, parameters) => `@(${parameters})=`)
         .replace(/@/g, '_anon') // Replace @ with anonymous fn name
         .replace(/^{(.*?)}(.*){(.*?)}$/, (match, requirements, expression, fulfillments) => {
-          this.requirements = requirements.split(' ');
-          this.fulfillments = fulfillments.split(' ');
+          newRequirements = requirements.split(' ').filter((s) => s);
+          this.fulfillments = fulfillments.split(' ').filter((s) => s);
 
           return expression;
         });
+
+      this.requirements?.forEach((r) => {
+        if (!newRequirements.includes(r)) {
+          Text.assignments.removeEventListener(r, this.handleAssignment);
+        }
+      });
+
+      newRequirements.forEach((r) => {
+        if (!this.requirements?.includes(r)) {
+          Text.assignments.addEventListener(r, this.handleAssignment);
+        }
+      });
+
+      this.requirements = newRequirements;
     }
 
     if (parsedText && parsedText.includes(':')) {
@@ -1057,6 +1082,8 @@ export default function Text(text, pos) {
   };
 
   this.render = (ctx) => {
+    this.dirty = false;
+
     const a = this.properties[rtv.frame];
 
     if (!a) {


### PR DESCRIPTION
Hi. This pull request initialises an `EventTarget` instance in `src/tools/text.js` which is used to signal changes in the scope of the parser by sending events with names equal to the modified variables. The `Text` class emits and handles these events (at most once per frame to prevent infinite loops). This works for every text box which uses the `{<requirements>}<expression>{<fulfilments>}` format.