### PR TITLE
Fall back to default monospace font if custom fonts are missing

### DIFF
--- a/src/resources.js
+++ b/src/resources.js
@@ -20,9 +20,9 @@ export const CANVAS_BG = 'white';
 export const COLORS = ['#000000', '#E74C3C', '#2980B9', '#FFA400', '#66E07A', '#cccccc'];
 
 export const FONT = {
-  SMALL: '26px Courier',
-  MENU: '30px Courier',
-  ANIM: IS_MAC ? '40px Menlo' : '40px Courier New',
+  SMALL: '26px Courier, monospace',
+  MENU: '30px Courier, monospace',
+  ANIM: `${IS_MAC ? '40px Menlo' : '40px Courier New'}, monospace`,
 };
 
 export const SCALE_FACTOR = 2; // retina


### PR DESCRIPTION
Hello. Some systems don't have the fonts specified in `src/resources.js` installed and display characters jumbled together (I don't know the reason why, but it doesn't look pleasant). `src/resources.js` is modified so that the default monospace font (whatever it is) is used when the custom fonts are not available.
